### PR TITLE
Add Jest configuration for TypeScript support

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};


### PR DESCRIPTION
This PR adds proper Jest configuration for TypeScript support. Changes include:

- Added jest.config.js with TypeScript preset
- Configured proper test file extensions and patterns
- Verified all tests are passing

All tests are now passing successfully.